### PR TITLE
Use dots when numbering in languages other than chinese

### DIFF
--- a/plugins/teedoc-plugin-theme-default/teedoc_plugin_theme_default/assets/light.css
+++ b/plugins/teedoc-plugin-theme-default/teedoc_plugin_theme_default/assets/light.css
@@ -530,21 +530,23 @@ html[lang^=zh] #article_content #blog_list h2:before {
     counter-reset: toc_l3;
 }
 #toc a.node-name--H1:before {
-	counter-increment: toc_l1;
+    counter-increment: toc_l1;
 }
 #toc a.node-name--H2:before {
-	counter-increment: toc_l2;
-	content: counter(toc_l2, upper-roman) "、";
-}
-html[lang^=zh] #toc a.node-name--H2:before {
-    content: counter(toc_l2, simp-chinese-informal) "、";
-}
-html[lang^=en] #toc a.node-name--H2:before {
+    counter-increment: toc_l2;
     content: counter(toc_l2, upper-roman) ".\00a0";
 }
-#toc a.node-name--H3:before, #toc a.node-name--H3:before {
-	counter-increment: toc_l3;
-    content: counter(toc_l2, decimal) ". " counter(toc_l3, decimal) "、";
+html[lang^=zh] #toc a.node-name--H2:before {
+    counter-increment: toc_l2;
+    content: counter(toc_l2, simp-chinese-informal) "、";
+}
+#toc a.node-name--H3:before {
+    counter-increment: toc_l3;
+    content: counter(toc_l2, decimal) "." counter(toc_l3, decimal) ".\00a0";
+}
+html[lang^=zh] #toc a.node-name--H3:before {
+    counter-increment: toc_l3;
+    content: counter(toc_l2, simp-chinese-informal) "." counter(toc_l3, simp-chinese-informal) "、";
 }
 .heading_no_counter #toc a.node-name--H2:before {
 	content: "";

--- a/plugins/teedoc-plugin-theme-default/teedoc_plugin_theme_default/assets/light.css
+++ b/plugins/teedoc-plugin-theme-default/teedoc_plugin_theme_default/assets/light.css
@@ -539,9 +539,12 @@ html[lang^=zh] #article_content #blog_list h2:before {
 html[lang^=zh] #toc a.node-name--H2:before {
     content: counter(toc_l2, simp-chinese-informal) "、";
 }
+html[lang^=en] #toc a.node-name--H2:before {
+    content: counter(toc_l2, upper-roman) ".\00a0";
+}
 #toc a.node-name--H3:before, #toc a.node-name--H3:before {
 	counter-increment: toc_l3;
-    content: counter(toc_l2, decimal) "." counter(toc_l3, decimal) "、";
+    content: counter(toc_l2, decimal) ". " counter(toc_l3, decimal) "、";
 }
 .heading_no_counter #toc a.node-name--H2:before {
 	content: "";

--- a/plugins/teedoc-plugin-theme-default/teedoc_plugin_theme_default/assets/main.js
+++ b/plugins/teedoc-plugin-theme-default/teedoc_plugin_theme_default/assets/main.js
@@ -210,7 +210,7 @@ function addSequence(){
             if(isZh){
                 var seq = toChineseNumber(counth2) + '、';
             }else{
-                var seq = counth2 + '、';
+                var seq = counth2 + '. ';
             }
             headings[i].insertAdjacentHTML('afterbegin', '<span class="sequence">' + seq + '</span>');
         } else if(headings[i].tagName == "H3"){

--- a/plugins/teedoc-plugin-theme-default/teedoc_plugin_theme_default/assets/main.js
+++ b/plugins/teedoc-plugin-theme-default/teedoc_plugin_theme_default/assets/main.js
@@ -201,28 +201,37 @@ function addSequence(){
             return;
         }
     }
+
+    var headerJoiner = ".";
+    var headerEnd = ". ";
+    if (isZh) {
+        headerEnd = "、";
+    }
+
     for(var i=0; i<headings.length; ++i){
         if(headings[i].tagName == "H1"){
             counth2 = 0;
-        } else if(headings[i].tagName == "H2"){
+            continue;
+        }
+
+        if(headings[i].tagName == "H2"){
             counth2 += 1;
             counth3 = 0;
-            if(isZh){
-                var seq = toChineseNumber(counth2) + '、';
-            }else{
-                var seq = counth2 + '. ';
-            }
-            headings[i].insertAdjacentHTML('afterbegin', '<span class="sequence">' + seq + '</span>');
+            var counts = [counth2]; 
         } else if(headings[i].tagName == "H3"){
             counth3 += 1;
             counth4 = 0;
-            var seq = counth2 + '.' + counth3 + "、";
-            headings[i].insertAdjacentHTML('afterbegin', '<span class="sequence">' + seq + '</span>');
+            var counts = [counth2, counth3];
         } else if(headings[i].tagName == "H4"){
             counth4 += 1;
-            var seq = counth2 + '.' + counth3 + '.' + counth3 + "、";
-            headings[i].insertAdjacentHTML('afterbegin', '<span class="sequence">' + seq + '</span>');
+            var counts = [counth2, counth3, counth4];
         }
+
+        if (isZh){
+            var counts = counts.map(toChineseNumber);
+        }
+        var seq = counts.join(headerJoiner) + headerEnd
+        headings[i].insertAdjacentHTML('afterbegin', '<span class="sequence">' + seq + '</span>');
     }
 }
 


### PR DESCRIPTION
I have made it so that dots `.` are used instead of enumeration commas `、` if the language is not chinese. I believe this is the most common punctuation for this, so i made it for all languages except chinese.
I had to use `.\00a0` to put a space between the enumeration and the title on the sidebar. Since the dot does not have built-in space, unlike `、`, it sits right next to it otherwise.