### PR TITLE
Add custom name parse

### DIFF
--- a/plugins/teedoc-plugin-search/teedoc_plugin_search/__init__.py
+++ b/plugins/teedoc-plugin-search/teedoc_plugin_search/__init__.py
@@ -149,7 +149,11 @@ class Plugin(Plugin_Base):
             self.docs_name[url] = url
         else:
             self.docs_name[url] = doc_config["name"]
-        self.doc_locale = doc_config["locale"] if "locale" in doc_config else None
+            
+        locale = doc_config["locale"] if "locale" in doc_config else None
+        if ":" in locale:
+            locale = locale[:locale.index(":")]
+        self.doc_locale = locale
         # self.new_config = copy.deepcopy(self.config)
         # self.new_config = update_config(self.new_config, new_config)
         self.new_config = new_config

--- a/teedoc/locales/ja/LC_MESSAGES/messages.po
+++ b/teedoc/locales/ja/LC_MESSAGES/messages.po
@@ -7,26 +7,26 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-03 17:41+0800\n"
+"POT-Creation-Date: 2025-02-26 18:57+0800\n"
 "PO-Revision-Date: 2021-09-09 20:17+0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ja\n"
 "Language-Team: ja <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.17.0\n"
 
-#: teedoc_main.py:1468
+#: teedoc_main.py:1534
 msgid "no_translate_title"
 msgstr ""
 
-#: teedoc_main.py:1469
+#: teedoc_main.py:1535
 msgid "no_translate_hint"
 msgstr ""
 
-#: teedoc_main.py:1470
+#: teedoc_main.py:1536
 msgid "visit_hint"
 msgstr ""
 

--- a/teedoc/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/teedoc/locales/zh_CN/LC_MESSAGES/messages.po
@@ -7,26 +7,26 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-03 17:41+0800\n"
+"POT-Creation-Date: 2025-02-26 18:57+0800\n"
 "PO-Revision-Date: 2021-09-09 20:43+0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_Hans_CN\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.17.0\n"
 
-#: teedoc_main.py:1468
+#: teedoc_main.py:1534
 msgid "no_translate_title"
 msgstr ""
 
-#: teedoc_main.py:1469
+#: teedoc_main.py:1535
 msgid "no_translate_hint"
 msgstr ""
 
-#: teedoc_main.py:1470
+#: teedoc_main.py:1536
 msgid "visit_hint"
 msgstr ""
 

--- a/teedoc/locales/zh_TW/LC_MESSAGES/messages.po
+++ b/teedoc/locales/zh_TW/LC_MESSAGES/messages.po
@@ -7,26 +7,26 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-03 17:41+0800\n"
+"POT-Creation-Date: 2025-02-26 18:57+0800\n"
 "PO-Revision-Date: 2021-10-11 13:57+0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_Hant_TW\n"
 "Language-Team: zh_Hant_TW <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.17.0\n"
 
-#: teedoc_main.py:1468
+#: teedoc_main.py:1534
 msgid "no_translate_title"
 msgstr ""
 
-#: teedoc_main.py:1469
+#: teedoc_main.py:1535
 msgid "no_translate_hint"
 msgstr ""
 
-#: teedoc_main.py:1470
+#: teedoc_main.py:1536
 msgid "visit_hint"
 msgstr ""
 

--- a/teedoc/teedoc_main.py
+++ b/teedoc/teedoc_main.py
@@ -317,18 +317,33 @@ def generate_navbar_language_items(routes, doc_configs, addtion_items={}):
     '''
     items = []
     for url, dir in routes.items():
-        locale = Locale.parse(doc_configs[url]["locale"])
+        locale = doc_configs[url]["locale"]
+        localname = None
+        if ":" in locale:
+            locale = locale.split(":")
+            localname = locale[1] if locale[1] else None   
+            locale = locale[0]     
+        if not localname:
+            locale = Locale.parse(doc_configs[url]["locale"])
+            localname = locale.language_name + (" " + locale.script_name if locale.script_name else "")  
         item = {
             "url": url,
-            "label": locale.language_name + (" " + locale.script_name if locale.script_name else ""),
+            "label": localname,
             "comment": "language"
         }
         items.append(item)
     for url, locale in addtion_items.items():
-        locale = Locale.parse(locale)
+        localname = None
+        if ":" in locale:
+            locale = locale.split(":")
+            localname = locale[1] if locale[1] else None
+            locale = locale[0]  
+        if not localname:
+            locale = Locale.parse(locale)
+            localname = locale.language_name + (" " + locale.script_name if locale.script_name else "")          
         item = {
             "url": url,
-            "label": locale.language_name + (" " + locale.script_name if locale.script_name else ""),
+            "label": localname,
             "comment": "language"
         }
         items.append(item)
@@ -827,6 +842,8 @@ def construct_html(html_template, html_templates_i18n_dirs, htmls, header_items_
     template_root = os.path.join(doc_src_path, site_config["layout_root_dir"]) if "layout_root_dir" in site_config else os.path.join(doc_src_path, "layout")
     theme_layout_root = os.path.dirname(html_template)
     locale = doc_config["locale"].replace("-", "_") if "locale" in doc_config else None
+    if ":" in locale:
+        locale = locale[:locale.index(":")]
     lang = locale.replace("_", "-") if locale else None
     renderer0 = Renderer(os.path.basename(html_template), [theme_layout_root], log, html_templates_i18n_dirs, locale=locale)
     files = {}
@@ -1509,6 +1526,8 @@ def parse(type_name, plugin_func, routes, routes_trans, site_config, doc_src_pat
                 root_dir = os.path.abspath(os.path.dirname(__file__))
                 try:
                     locale = doc_config["locale"]
+                    if ":" in locale:
+                        locale = locale[:locale.index(":")]
                     lang = gettext.translation('messages', localedir=os.path.join(root_dir, 'locales'), languages=[locale])
                     lang.install()
                     _ = lang.gettext


### PR DESCRIPTION
I add a function to parse custom language name.
You can set your custom name behind a `:`, if not set or set a null value, it will display default value.

For example: `"locale" : "en:Englishese"`
It will display `Language: Englishese` not `English`.

Set this to use default: `"locale" : "en"`(without colon) or `"locale" : "en:"`(without custom name).

我添加了一个解析自定义语言名的功能，在locale后面加个 `:` 再加你的自定义名，若不设置或设置为空则使用默认名。

例如：`"locale" : "zh_CN:繁体中文"`
将显示`Language: 繁体中文` 而非`中文 简体`.

若使用默认则写`"locale" : "zh_CN"`（不加冒号） or `"locale" : "zh_CN:"`（不写自定义名）。